### PR TITLE
Fix message replied

### DIFF
--- a/slackminion/slack/user.py
+++ b/slackminion/slack/user.py
@@ -1,7 +1,7 @@
 import logging
 
 
-class SlackUser(object):
+class  SlackUser(object):
     """Represents a Slack user"""
     def __init__(self, id, sc=None):
         self.id = id

--- a/slackminion/slack/user.py
+++ b/slackminion/slack/user.py
@@ -1,7 +1,7 @@
 import logging
 
 
-class  SlackUser(object):
+class SlackUser(object):
     """Represents a Slack user"""
     def __init__(self, id, sc=None):
         self.id = id

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -103,6 +103,10 @@ class TestDispatcher(object):
         e = SlackEvent(DummySlackConnection(), **{'text': 'Not a command'})
         assert self.object.push(e) == (None, None)
 
+    def test_push_message_replied_event(self):
+        e = SlackEvent(DummySlackConnection(), **{'subtype': 'message_replied'})
+        assert self.object.push(e) == (None, None)
+
     def test_push_no_user(self):
         self.object.register_plugin(self.p)
         e = SlackEvent(DummySlackConnection(), **{'text': '!abc'})


### PR DESCRIPTION
message_replied is a type of message event and does not have the text
attribute. This was causing Attribute errors when parsing. Since
message_replied is not a type where we want to action the messages,
adding hooks to disable them in the dispatcher.

https://api.slack.com/events/message/message_replied