### PR TITLE
Ignore message_changed events

### DIFF
--- a/slackminion/dispatcher.py
+++ b/slackminion/dispatcher.py
@@ -46,7 +46,7 @@ class MessageDispatcher(object):
         self.log = logging.getLogger(type(self).__name__)
         self.commands = {}
         self.ignored_channels = []
-        self.ignored_events = ['message_replied']
+        self.ignored_events = ['message_replied', 'message_changed']
 
     def push(self, message):
         """
@@ -78,6 +78,8 @@ class MessageDispatcher(object):
         """
         message_replied event is not truly a message event and does not have a message.text
         don't process such events
+
+        commands may not be idempotent, so ignore message_changed events.
         """
         if hasattr(message, 'subtype') and message.subtype in self.ignored_events:
             return True


### PR DESCRIPTION
When a message is edited, slack resends the message setting event type
to message_changed. Since commands may not be idempotent, there is risk
in reprocessing these messages. For now, ignore message changed events.
If a plugin needs to reprocess these messages, we can decide to handle
these events at that time.