### PR TITLE
Add option for rtm start

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ MarkupSafe==0.23
 PyYAML==3.11
 requests==2.10.0
 six==1.10.0
-slackclient==1.3.0
+slackclient==1.3.1
 websocket-client==0.37.0
 Werkzeug==0.11.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-Flask==0.10.1
-itsdangerous==0.24
-Jinja2==2.8
-MarkupSafe==0.23
-PyYAML==3.11
-requests==2.10.0
-six==1.10.0
-slackclient==1.3.1
-websocket-client==0.37.0
-Werkzeug==0.11.10
+-e . 

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,16 @@ setup(
         description='A python bot framework for slack',
         package_data={'slackminion': ['templates/*']},
         install_requires=[
-            'Flask',
-            'PyYAML',
-            'requests',
-            'six',
-            'slackclient',
-            'websocket-client',
+            'Flask==0.10.1',
+            'itsdangerous==0.24',
+            'Jinja2==2.8',
+            'MarkupSafe==0.23',
+            'PyYAML==3.11',
+            'requests >=2.11, <3.0a0',
+            'six >=1.10, <2.0a0',
+            'slackclient==1.3.1',
+            'websocket-client >=0.35, <0.55.0',
+            'Werkzeug==0.11.10',
         ],
         setup_requires=[
             'pytest-runner'

--- a/slackminion/bot.py
+++ b/slackminion/bot.py
@@ -82,7 +82,7 @@ class Bot(object):
                 for event in method.events:
                     self.event_handlers[event] = method
 
-    def run(self):
+    def run(self, start=True):
         """Connects to slack and enters the main loop."""
         # Fail out if setup wasn't run
         if not self.is_setup:
@@ -96,7 +96,7 @@ class Bot(object):
         try:
             while self.runnable:
                 if self.reconnect_needed:
-                    if not self.sc.rtm_connect():
+                    if not self.sc.rtm_connect(with_team_state=start):
                         return False
                     self.reconnect_needed = False
                     if first_connect:

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = '0.9.0'
+version = '0.9.1'


### PR DESCRIPTION
1) By default slack client uses rtm.start call when connecting to the API.
For larger teams, this causes errors. Provide ability to switch to the
light weight rtm.connect call. The old behavior is still the default but
slackminion users now have the ability to chose between rtm.start and
rtm.connect by passing a start=<boolean> to the run method.

2) Upgrade slackclient to fix a bug with websockets.

Reference: https://python-slackclient.readthedocs.io/en/latest/real_time_messaging.html#rtm-start-vs-rtm-connect