### PR TITLE
Add ability to send threaded responses

### DIFF
--- a/slackminion/bot.py
+++ b/slackminion/bot.py
@@ -143,19 +143,21 @@ class Bot(object):
         if not self.test_mode:
             self.plugins.save_state()
 
-    def send_message(self, channel, text):
+    def send_message(self, channel, text, thread=None, reply_broadcast=None):
         """
         Sends a message to the specified channel
 
         * channel - The channel to send to.  This can be a SlackChannel object, a channel id, or a channel name
         (without the #)
         * text - String to send
+        * thread - reply to the thread. See https://api.slack.com/docs/message-threading#threads_party
+        * reply_broadcast - Set to true to indicate your reply is germane to all members of a channel
         """
         # This doesn't want the # in the channel name
         if isinstance(channel, SlackRoomIMBase):
             channel = channel.id
         self.log.debug("Trying to send to %s: %s", channel, text)
-        self.sc.rtm_send_message(channel, text)
+        self.sc.rtm_send_message(channel, text, thread=None, reply_broadcast=None)
 
     def send_im(self, user, text):
         """

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = '0.9.2'
+version = '0.9.3'


### PR DESCRIPTION
Update signature for rtm_send_message. This enabled the ability to send
threaded responses.

See https://slack.dev/python-slackclient/real_time_messaging.html#sending-messages-via-the-rtm-api